### PR TITLE
Fix: incorporate added bb_thread_t typedef

### DIFF
--- a/steamsdk.mod/glue/glue.cpp
+++ b/steamsdk.mod/glue/glue.cpp
@@ -380,9 +380,9 @@ public:
         th = std::thread([=]() {
 
 #ifdef _WIN32
-			auto nativeThread = ::GetCurrentThreadId();
+			bb_thread_t nativeThread = ::GetCurrentThreadId();
 #else
-			void * nativeThread = (void*)pthread_self();
+			bb_thread_t nativeThread = pthread_self();
 #endif
 			bbThread = bbThreadRegister(nativeThread);
 


### PR DESCRIPTION
In https://github.com/bmx-ng/brl.mod/commit/120dc1f3ffeb7175d90aea2b615bac320195cb19 a new typedef for threads was added.

This PR simply adds this one instead of using the `void *` which results in the compiler choosing the wrong function definition (the win32 one).


Closes bmx-ng/bmx-ng/issues/197